### PR TITLE
Filter Icons and Control Dash logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ node_modules
 *.DS_Store
 app/bower_components
 app/sample_data
-app/scripts/testConf.coffee
-app/scripts/core/filterPreview.coffee
 test/bower_components
 dist/
 ToDo.md

--- a/app/scripts/alchemy/core/controls.coffee
+++ b/app/scripts/alchemy/core/controls.coffee
@@ -1,61 +1,29 @@
-# alchemy.zoomControls = 
-        # init: ->
-        #     if conf.zoomControls
-        #         d3.select(".alchemy")
-        #           .append("div", "#controls-container")
-        #           .attr("id", "zoom-controls")
-        #           .attr("class", conf.controlOrientation)
-        #           .html("<button id='zoom-in'  class='btn btn-defualt btn-primary'><i class='fa fa-plus  fa-1x'></i></button>
-        #                  <button id='zoom-out' class='btn btn-default btn-primary'><i class='fa fa-minus fa-1x'></i></button>")
-                
-        #     d3.select('#zoom-in').on("click", () -> alchemy.interactions.clickZoom 'in' )
-        #     d3.select('#zoom-out').on("click", () -> alchemy.interactions.clickZoom 'out' )
-
 alchemy.controlDash = 
     init: () ->
-        # add dashboard wrapper
-        d3.select(".alchemy")
-            .append("div")
-            .attr("id", "control-dash-wrapper")
-            .attr("class", "col-md-4 off-canvas")
+        if conf.showControlDash is true 
+            # add dashboard wrapper
+            d3.select(".alchemy")
+                .append("div")
+                .attr("id", "control-dash-wrapper")
+                .attr("class", "col-md-4 off-canvas")
 
-        # add the dash toggle button 
-        d3.select("#control-dash-wrapper") 
-            .append("i")
-            .attr("id", "dash-toggle")
-            .attr("class", "fa fa-flask col-md-offset-12")
+            # add the dash toggle button 
+            d3.select("#control-dash-wrapper") 
+                .append("i")
+                .attr("id", "dash-toggle")
+                .attr("class", "fa fa-flask col-md-offset-12")
 
-        # add the control dash
-        d3.select("#control-dash-wrapper") 
-            .append("div")
-            .attr("id", "control-dash")
-            .attr("class", "col-md-12")
+            # add the control dash
+            d3.select("#control-dash-wrapper") 
+                .append("div")
+                .attr("id", "control-dash")
+                .attr("class", "col-md-12")
 
-        d3.select('#dash-toggle').on('click', alchemy.interactions.toggleControlDash)
+            d3.select('#dash-toggle').on('click', alchemy.interactions.toggleControlDash)
 
-        alchemy.controlDash.zoomCtrl()
-        alchemy.controlDash.filters()
-        alchemy.controlDash.stats()
-
-        # add zoom controls
-        # d3.select("#control-dash-wrapper")
-        #     .append("div")
-        #     .attr("id", "zoom-controls")
-        #     .attr("class", "col-md-offset-12")
-        #     .html("<button id='zoom-in'  class='btn btn-defualt btn-primary'><i class='fa fa-plus'></i></button>
-        #                 <button id='zoom-out' class='btn btn-default btn-primary'><i class='fa fa-minus'></i></button>")
-
-        #add filters
-        # d3.select("#control-dash")
-        #     .append("div")
-        #     .attr("id", "filters")
-
-        #add stats
-        # d3.select("#control-dash")
-        #     .append("div")
-        #     .attr("id", "stats")
-        # d3.select('#zoom-in').on("click", () -> alchemy.interactions.clickZoom 'in' )
-        # d3.select('#zoom-out').on("click", () -> alchemy.interactions.clickZoom 'out' )
+            alchemy.controlDash.zoomCtrl()
+            alchemy.controlDash.filters()
+            alchemy.controlDash.stats()
 
     zoomCtrl: () ->
         if conf.zoomControls 

--- a/app/scripts/alchemy/core/filters.coffee
+++ b/app/scripts/alchemy/core/filters.coffee
@@ -108,10 +108,12 @@ alchemy.filters =
                         </form>
                       """
         d3.select('#control-dash #filters').html(filter_html)
-        # d3.select('#filters>h3')
-        #     .on('hide.bs.collapse', () -> d3.select('#filters>h3').html('<span class="fa fa-caret-right"></span>Show Filters'))
-        #     .on('show.bs.collapse', () -> d3.select('#filters>h3').html('<span class="fa fa-caret-down"></span>Hide Filters'))
-
+        d3.select("#filters>h3")    
+            .on('click', () ->
+                if d3.select('#filters>form').classed("in")
+                    d3.select("#filters>h3").html("Filters<span class = 'fa fa-caret-right'></span>")
+                else d3.select("#filters>h3").html("Filters<span class = 'fa fa-caret-down'></span>")
+            )
         $('#filters form').submit(false)
 
     #create relationship filters
@@ -119,7 +121,7 @@ alchemy.filters =
         rel_filter_html = """
                            <div id="filter-relationships" class="btn-group">
                                 <button type="button" data-target = "#rel-dropdown" class="btn btn-default" data-toggle="collapse">
-                                    Edge Types<span class="fa fa-caret-down"></span>
+                                    Edge Types<span class="fa fa-caret-right"></span>
                                 </button>
                                 <ul id="rel-dropdown" class="collapse list-group" role="menu">
                                 </ul>
@@ -127,13 +129,19 @@ alchemy.filters =
 
                            """
         $('#filters form').append(rel_filter_html)
+        d3.select("#filter-relationships>button")    
+            .on('click', () ->
+                if d3.select('#rel-dropdown').classed("in")
+                    d3.select("#filter-relationships>button").html("Edge Types<span class = 'fa fa-caret-right'></span>")
+                else d3.select("#filter-relationships>button").html("Edge Types<span class = 'fa fa-caret-down'></span>")
+            )
 
     #create node filters
     showNodeFilters: () ->
         node_filter_html = """
                            <div id="filter-nodes" class="btn-group">
                                 <button type="button" data-target="#node-dropdown" class="btn btn-default" data-toggle="collapse">
-                                    Node Types<span class="fa fa-caret-down"></span>
+                                    Node Types<span class="fa fa-caret-right"></span>
                                 </button>
                                 <ul id="node-dropdown" class="collapse list-group" role="menu">
                                 </ul>
@@ -141,6 +149,12 @@ alchemy.filters =
 
                            """
         $('#filters form').append(node_filter_html)
+        d3.select("#filter-nodes>button")    
+            .on('click', () ->
+                if d3.select('#node-dropdown').classed("in")
+                    d3.select("#filter-nodes>button").html("Node Types<span class = 'fa fa-caret-right'></span>")
+                else d3.select("#filter-nodes>button").html("Node Types<span class = 'fa fa-caret-down'></span>")
+            )
 
     #update filters
     update: () ->

--- a/app/scripts/alchemy/core/stats.coffee
+++ b/app/scripts/alchemy/core/stats.coffee
@@ -1,8 +1,9 @@
 alchemy.stats = 
     init: () -> 
-        alchemy.stats.show()
-        alchemy.stats.update()
-        alchemy.stats.insertSVG()
+        if conf.showStats is true
+            alchemy.stats.show()
+            alchemy.stats.update()
+            alchemy.stats.insertSVG()
     show: () -> 
         stats_html = """
                         <h3 data-toggle="collapse" data-target="#stats #all-stats">
@@ -14,8 +15,12 @@ alchemy.stats =
                             <ul class = "list-group" id="rel-stats"></ul>  
                     """
         d3.select('#stats').html(stats_html)
-        # d3.select('h3')
-        #     .on("show.bs.collapse").html("<span class = 'fa fa-caret-down'></span>")
+        d3.select('#stats>h3')
+            .on('click', () ->
+                if d3.select('#all-stats').classed("in")
+                    d3.select("#stats>h3").html("Statistics<span class = 'fa fa-caret-right'></span>")
+                else d3.select("#stats>h3").html("Statistics<span class = 'fa fa-caret-down'></span>")
+            )
 
     nodeStats: () ->
         #general node stats
@@ -92,17 +97,7 @@ alchemy.stats =
 
 
     update: () -> 
-        #get all the nodes
-        # nodeNum = d3.selectAll(".node")[0].length
-        # activeNodes = d3.selectAll(".node.active")[0].length
-        # inactiveNodes = d3.selectAll(".node.inactive")[0].length
-        # console.log "number of nodes: " + nodeNum + " activeNodes: " + activeNodes + " inactiveNodes: " + inactiveNodes  
-
-        # #get all the edges
-        # edgeNum = d3.selectAll(".edge")[0].length
-        # activeEdges = d3.selectAll(".edge.active")[0].length
-        # inactiveEdges = d3.selectAll(".edge.inactive")[0].length
-        # console.log "number of edges: " + edgeNum + " activeEdges: " + activeEdges + " inactiveEdges: " + inactiveEdges
-
-        alchemy.stats.nodeStats()
-        alchemy.stats.edgeStats()
+        if conf.nodeStats is true
+            alchemy.stats.nodeStats()
+        if conf.edgeStats is true
+            alchemy.stats.edgeStats()

--- a/app/scripts/alchemy/defaultConf.coffee
+++ b/app/scripts/alchemy/defaultConf.coffee
@@ -34,6 +34,13 @@ defaults =
     addNodes: false # not currently implemented
     addEdges: false # not currently implemented
 
+    #Control Dash
+    showControlDash: false 
+
+    #Stats
+    showStats: false
+    nodeStats: false
+    edgeStats: false
 
     # Filtering
     showFilters: false
@@ -41,7 +48,7 @@ defaults =
     nodeFilters: false
 
     # Controls
-    controlOrientation: 'vertical'
+    # controlOrientation: 'vertical' no longer implemented or used
     zoomControls: false
 
     # Nodes

--- a/app/scripts/testConf.coffee
+++ b/app/scripts/testConf.coffee
@@ -1,0 +1,37 @@
+test = {}
+
+test.mouseOut = (d) ->
+    test.PopUp.transition()
+                .delay(500)
+                .remove()
+
+testConf = _.assign {},
+
+    caption: (n) ->
+        "#{n.caption}"
+
+    dataSource: '/sample_data/charlize.json'
+    # nodeMouseOver: (n) ->
+    #    $("#node-#{n.id}")[0].popover({title: "title", container: 'body'})
+    # nodeClick: (d) ->
+    #     test.nodeClick(d, window.alchemyConf.bio_url)
+
+    nodeRadius: 7
+    rootNodeRadius: 10
+
+    nodeTypes: {"node_type":["movie", "award", "person"]}
+    edgeTypes: ["ACTED_IN", "NOMINATED", "RECEIVED", "PARENT_OF", "PARTNER_OF", "BORN_AT", "PRODUCED"]
+
+    #show control dash, zoom controls, all filters, and all stats.
+    showControlDash: true
+
+    showStats: true
+    nodeStats: true
+    edgeStats: true
+
+    showFilters: true
+    nodeFilters: true
+    edgeFilters: true
+    zoomControls: true
+    
+alchemy.conf = _.assign(alchemy.conf, testConf)

--- a/app/styles/_svg.scss
+++ b/app/styles/_svg.scss
@@ -1,5 +1,5 @@
 svg {
-    background: #252525;
+    background: black;
     // margin-bottom: -3px;
     position: absolute;
     // top: 0;


### PR DESCRIPTION
Filters (and children) and statistics now have state-dependent carets. changed svg background color to black. Cleaned up and removed unnecessary code in controls.coffee. Added appropriate conf options and incorporated that logic into the control dash (controls, startGraph, filters, stats and zoom).
