### PR TITLE
Update BUILD.md with current instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -22,6 +22,9 @@ npm install -g coffee-script
 # Install bower for frontend dependency management
 npm install -g bower
 
+# Install grunt for running tasks
+npm install -g grunt-cli
+
 # Install Compass for compiling Sass into css
 gem install compass
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -54,7 +54,7 @@ Alchemy will now be running at localhost:9000.  The Alchemy app that is running 
 
 Testing
 -------
-Alchemy uses Karma to run test in the mocha framework.  There are a few different that tests are run:  
+Alchemy uses Karma to run test in the mocha framework.  There are a few different tests that are run:  
 
 1. You can run Alchemy's test locally with the `grunt test` command
 1. Continuous integrations runs the test on pull requests using the `grunt test:pr`

--- a/BUILD.md
+++ b/BUILD.md
@@ -19,6 +19,9 @@ npm install -g yo
 # Install Coffee for compiling CoffeeScript into JavaScript
 npm install -g coffee-script
 
+# Install bower for frontend dependency management
+npm install -g bower
+
 # Install Compass for compiling Sass into css
 gem install compass
 


### PR DESCRIPTION
The current BUILD.md leaves out instructions on downloading bower and grunt. I've included those instructions and fixed a grammar error.